### PR TITLE
Optimize for smaller build-size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,11 @@ homepage = "https://github.com/yavko/hyprland-rs"
 repository = "https://github.com/yavko/hyprland-rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[profile.release]
+opt-level = "z"
+strip = true
+lto = true
+
 [dev-dependencies]
 rusty-hook = "^0.11.2"
 


### PR DESCRIPTION
Added
```
[profile.release]
opt-level = "z"
strip = true
lto = true
```

To `Cargo.toml` which reduces the total size of `target/release` from ~200MB+ to ~139MB.